### PR TITLE
:lipstick: Rework emoji usage on frontend

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -62,7 +62,7 @@
     <SortFilter name="↕️ Sort by" />
     <TextFilter crates={t_crates} bind:selected={selected_f} />
     <Filter
-      name="Categories"
+      name="🧰 Categories"
       values={t_indexes.category}
       bind:selected={selected_c}
     />

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -67,7 +67,7 @@
       bind:selected={selected_c}
     />
     <Filter
-      name="Dependencies"
+      name="⛓️ Dependencies"
       values={t_indexes.dependencies}
       bind:selected={selected_d}
     />

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -59,7 +59,7 @@
 <h1>{selected_crates.length} awesome drivers waiting for you!</h1>
 <main>
   <div class="filters">
-    <SortFilter name="Sort by" />
+    <SortFilter name="↕️ Sort by" />
     <TextFilter crates={t_crates} bind:selected={selected_f} />
     <Filter
       name="Categories"

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -77,7 +77,7 @@
       bind:selected={selected_i}
     />
     <Filter
-      name="👮 License"
+      name="📄 License"
       values={t_indexes.license}
       bind:selected={selected_l}
     />

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -72,7 +72,7 @@
       bind:selected={selected_d}
     />
     <Filter
-      name="Interfaces"
+      name="🔌 Interfaces"
       values={t_indexes.interfaces}
       bind:selected={selected_i}
     />

--- a/frontend/src/lib/Crate.svelte
+++ b/frontend/src/lib/Crate.svelte
@@ -129,7 +129,7 @@
     {/if}
   </div>
   <div class="stats-box">
-    <p>👮 License: {crate.license}</p>
+    <p>📄 License: {crate.license}</p>
     <p>⬇️ All-Time: {crate.downloads}</p>
     <p>⬇️ This version: {crate.this_version_downloads}</p>
     <p>

--- a/frontend/src/lib/Crate.svelte
+++ b/frontend/src/lib/Crate.svelte
@@ -74,7 +74,7 @@
     {/if}
     {#if crate.interfaces && (crate.interfaces.i2c || crate.interfaces.spi)}
       <p>
-        🚌 Interfaces:
+        🔌 Interfaces:
         {#if crate.interfaces.i2c}I2C{/if}
         {#if crate.interfaces.spi}SPI{/if}
       </p>


### PR DESCRIPTION
This PR adds and changes the emoji usage on the frontend, adding where missing and changing some to align better with common usage

### This
- changes the :police_officer: to :page_facing_up: to match gitmoji usage for license changes. Might be too close to :clipboard: used for datasheets at the moment.
- Use the :electric_plug: for the interface category. In my opinion this is a bit clearer than the currently used :bus:. This also adds it to the filter bar on top
- Use the :chains: for the dependency filter.
- Use the :arrow_up_down: for the sorting button.
- Use the :toolbox: for the categories. This is the closest I could find for toolkit or functionality, but I think it can be improved upon.

Let me know what you think and whether you agree. I'm fine with dropping or changing commits if you have other suggestions.

# Checklist

* [x] I agree that my contribution gets licensed under the MIT license, except for contributions to `driver-db` which
  get licensed under the CC0 license
