### PR TITLE
feat: Support multiple devices per driver crate (Fixes #90)

### DIFF
--- a/backend/src/driver_db.rs
+++ b/backend/src/driver_db.rs
@@ -14,7 +14,11 @@ pub struct Driver {
     /// Version of this driver description TOML schema
     pub manifest_version: semver::Version,
     /// Metadata about the driver
-    pub meta: Meta,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+    /// List of devices supported by this driver
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub devices: Vec<Meta>,
     /// List of development boards that house this chip
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub dev_boards: Vec<DevBoard>,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -46,7 +46,11 @@ pub struct FullCrate {
 }
 
 impl FullCrate {
-    pub fn new(driver_db: Driver, mut krate: dumpsterbase::Crate) -> anyhow::Result<Self> {
+    pub fn new(
+        driver_db: &Driver,
+        meta: driver_db::Meta,
+        mut krate: dumpsterbase::Crate,
+    ) -> anyhow::Result<Self> {
         let version = krate
             .versions
             .pop()
@@ -63,10 +67,10 @@ impl FullCrate {
             repository: krate.repository,
             created_at: krate.created_at,
             updated_at: krate.updated_at,
-            chip_meta: driver_db.meta,
-            dev_boards: driver_db.dev_boards,
-            interfaces: driver_db.interfaces,
-            resources: driver_db.resources,
+            chip_meta: meta,
+            dev_boards: driver_db.dev_boards.clone(),
+            interfaces: driver_db.interfaces.clone(),
+            resources: driver_db.resources.clone(),
             license: version.license,
             crate_size: version.crate_size,
             rust_version: version.rust_version,

--- a/driver-db-schema.json
+++ b/driver-db-schema.json
@@ -10,18 +10,31 @@
         "$ref": "#/$defs/DevBoard"
       }
     },
+    "devices": {
+      "description": "List of devices supported by this driver",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Meta"
+      }
+    },
     "interfaces": {
       "description": "Interfaces used by this chip",
       "$ref": "#/$defs/Interfaces"
     },
     "manifest_version": {
       "description": "Version of this driver description TOML schema",
-      "type": "string",
-      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+      "$ref": "#/$defs/SemVer"
     },
     "meta": {
       "description": "Metadata about the driver",
-      "$ref": "#/$defs/Meta"
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Meta"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "resources": {
       "description": "Blog articles and similar covering this driver and its usage",
@@ -33,8 +46,7 @@
   },
   "additionalProperties": false,
   "required": [
-    "manifest_version",
-    "meta"
+    "manifest_version"
   ],
   "$defs": {
     "BoardManufacturer": {
@@ -75,7 +87,7 @@
           "const": "Sensor::PowerMeter"
         },
         {
-          "description": "Sensors measuring acceleration\n\n These can also be used to determine where \"down\" is,\n using the gravitational acceleration.",
+          "description": "Sensors measuring acceleration\n\nThese can also be used to determine where \"down\" is,\nusing the gravitational acceleration.",
           "type": "string",
           "const": "Sensor::Accelerometer"
         },
@@ -110,7 +122,7 @@
           "const": "Sensor::Humidity"
         },
         {
-          "description": "Sensors measuring magnetic fields\n\n These are commonly used as compasses, measuring the\n magnetic field of the earth.",
+          "description": "Sensors measuring magnetic fields\n\nThese are commonly used as compasses, measuring the\nmagnetic field of the earth.",
           "type": "string",
           "const": "Sensor::Magnetometer"
         },
@@ -150,7 +162,7 @@
           "const": "Timer"
         },
         {
-          "description": "Clocks that keep track of wall time\n\n Often allow to measure time with an external battery.",
+          "description": "Clocks that keep track of wall time\n\nOften allow to measure time with an external battery.",
           "type": "string",
           "const": "Timer::RTC"
         }
@@ -221,6 +233,7 @@
           "items": {
             "type": "integer",
             "format": "uint8",
+            "maximum": 255,
             "minimum": 0
           }
         },
@@ -327,12 +340,12 @@
     "Resource": {
       "type": "object",
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "link": {
           "type": "string",
           "format": "uri"
+        },
+        "title": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -340,6 +353,10 @@
         "title",
         "link"
       ]
+    },
+    "SemVer": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
     },
     "Spi": {
       "type": "object",


### PR DESCRIPTION
- Updated Driver struct to support a list of 'devices' alongside the legacy 'meta' field.
- Updated FullCrate generation to produce one entry per device/chip.
- Updated read-driver-db to aggregate devices from both fields.
- Regenerated driver-db-schema.json.

# Checklist

* [ ] I agree that my contribution gets licensed under the MIT license, except for contributions to `driver-db` which
  get licensed under the CC0 license
